### PR TITLE
Changing Engine Node Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "webpack-dev-server": "2.11.2"
   },
   "engines": {
-    "node": "8.x.x"
+    "node": "10.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "webpack-dev-server": "2.11.2"
   },
   "engines": {
-    "node": "10.x.x"
+    "node": "11.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "webpack-dev-server": "2.11.2"
   },
   "engines": {
-    "node": ">=8.0.0 <=14.0.0"
+    "node": "8.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "webpack-dev-server": "2.11.2"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "webpack-dev-server": "2.11.2"
   },
   "engines": {
-    "node": "11.x.x"
+    "node": "12.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "webpack-dev-server": "2.11.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.0.0 <=14.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "webpack-dev-server": "2.11.2"
   },
   "engines": {
-    "node": "12.x.x"
+    "node": "11.x.x"
   }
 }


### PR DESCRIPTION
When we deployed the original engine node (>=8), heroku produced an error. This PR is to fix that error so it can be deployed. 